### PR TITLE
fix: session event display, PR links, and notification delivery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,50 @@ what was actually requested — no drive-by refactors.
 
 ---
 
+## Verification protocol: Jules web UI is the reference
+
+The Jules web UI (`jules.google.com`) is the ground truth for how
+sessions, activities, plans, and completion data should look. Every
+feature or fix to Jataayu's session surface **must** be verified
+against the web UI for the same session.
+
+**Tools:**
+
+- **AXe CLI** (`axe`) — drives the iOS simulator: tap, swipe,
+  screenshot, describe-ui. Use for navigating the app, taking
+  verification screenshots, and confirming tap targets.
+- **Chrome DevTools MCP** — connects to Chrome via autoConnect.
+  Use to inspect the Jules web UI: scrape rendered DOM content,
+  extract Angular component state, intercept button actions
+  (`window.open` patching), and compare what the web UI shows
+  against what Jataayu shows.
+
+**Protocol for feature/fix work on the session surface:**
+
+1. **Open the same session** in both Jataayu (simulator) and the
+   Jules web UI (Chrome). Use Chrome DevTools MCP to inspect what
+   the web UI renders — DOM elements, CSS classes, data bindings.
+2. **Compare every visible element.** Progress events, plan steps,
+   completion card, PR link, diff stats, timestamps, expandable
+   sections. If the web UI shows it and Jataayu doesn't, that's a
+   gap to investigate.
+3. **When the REST API falls short**, document it. The web UI uses
+   Google's internal batch RPC (`batchexecute`) which returns
+   richer data than the public REST API. Known gaps:
+   - Runtime duration is server-computed (we approximate with `~`)
+   - `changeSet` artifacts on progress events lack patch content
+     (file names not extractable for "Updated X, Y, Z" display)
+   - `outputs` array ordering is not guaranteed (search all, never
+     `.first`)
+4. **Screenshot every state** after a fix with `axe screenshot` and
+   visually compare to the web UI. Don't claim "verified" from
+   code review alone.
+5. **If a feature can't be replicated** due to REST API limitations,
+   note it explicitly in the PR/commit and in `docs/LEARNINGS.md`
+   rather than silently omitting it.
+
+---
+
 ## When touching the chat surface
 
 <details>

--- a/Jools/Core/Navigation/RootView.swift
+++ b/Jools/Core/Navigation/RootView.swift
@@ -32,6 +32,7 @@ struct RootView: View {
 struct MainTabView: View {
     @EnvironmentObject private var dependencies: AppDependency
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
     @State private var selectedTab: Tab = .home
     @State private var deepLinkedSession: SessionEntity?
     @State private var showNotificationPrimer = false
@@ -134,6 +135,29 @@ struct MainTabView: View {
             if let sessionId = NotificationBridge.shared.pendingSessionId {
                 NotificationBridge.shared.pendingSessionId = nil
                 Task { await navigateToSession(id: sessionId) }
+            }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            switch newPhase {
+            case .active:
+                // Returning to foreground: immediately check for
+                // session state transitions so notifications fire
+                // without waiting for a tab refresh or background
+                // task. This is separate from the polling service
+                // (which ChatView manages for its own session).
+                Task {
+                    guard let manager = dependencies.notificationManager else { return }
+                    let sessions = try? await dependencies.apiClient.listAllSessions(pageSize: 100)
+                    if let sessions {
+                        await manager.checkForTransitions(sessions)
+                    }
+                }
+            case .background:
+                // Ensure the next background task is queued every
+                // time we enter background, not just at launch.
+                BackgroundSessionChecker.scheduleNext()
+            default:
+                break
             }
         }
     }

--- a/Jools/Core/Navigation/RootView.swift
+++ b/Jools/Core/Navigation/RootView.swift
@@ -36,6 +36,7 @@ struct MainTabView: View {
     @State private var selectedTab: Tab = .home
     @State private var deepLinkedSession: SessionEntity?
     @State private var showNotificationPrimer = false
+    @State private var foregroundCheckTask: Task<Void, Never>?
 
     enum Tab: String, CaseIterable {
         case home
@@ -143,11 +144,13 @@ struct MainTabView: View {
                 // Returning to foreground: immediately check for
                 // session state transitions so notifications fire
                 // without waiting for a tab refresh or background
-                // task. This is separate from the polling service
-                // (which ChatView manages for its own session).
-                Task {
+                // task. Cancel any in-flight check to avoid stale
+                // responses racing with the new one.
+                foregroundCheckTask?.cancel()
+                foregroundCheckTask = Task {
                     guard let manager = dependencies.notificationManager else { return }
                     let sessions = try? await dependencies.apiClient.listAllSessions(pageSize: 100)
+                    guard !Task.isCancelled else { return }
                     if let sessions {
                         await manager.checkForTransitions(sessions)
                     }

--- a/Jools/Core/Notifications/BackgroundSessionChecker.swift
+++ b/Jools/Core/Notifications/BackgroundSessionChecker.swift
@@ -30,7 +30,11 @@ enum BackgroundSessionChecker {
     /// each background task completes.
     static func scheduleNext() {
         let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
-        request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
+        // Request the shortest practical interval. iOS won't guarantee
+        // this cadence — the system schedules based on battery, usage
+        // patterns, and resource pressure — but 5 min is the lowest
+        // value the OS respects at all (below that it clamps silently).
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 5 * 60)
         do {
             try BGTaskScheduler.shared.submit(request)
             logger.debug("Scheduled next background refresh")

--- a/Jools/Core/Persistence/Entities.swift
+++ b/Jools/Core/Persistence/Entities.swift
@@ -147,10 +147,10 @@ final class SessionEntity {
             updatedAt: dto.updateTime ?? Date()
         )
 
-        if let output = dto.outputs?.first?.pullRequest {
-            self.prURL = output.url
-            self.prTitle = output.title
-            self.prDescription = output.description
+        if let pr = dto.outputs?.lazy.compactMap({ $0.pullRequest }).first {
+            self.prURL = pr.url
+            self.prTitle = pr.title
+            self.prDescription = pr.description
         }
     }
 

--- a/Jools/Features/Chat/ChatView.swift
+++ b/Jools/Features/Chat/ChatView.swift
@@ -234,7 +234,8 @@ struct ChatMessagesList: View {
 
         let snapshots = ActivitySnapshotBuilder.build(
             from: activities,
-            fallback: session.activities
+            fallback: session.activities,
+            session: session
         )
         let effectiveState = session.effectiveState
         let canRespondToPlan = effectiveState == .awaitingPlanApproval

--- a/Jools/Features/Chat/ChatViewModel.swift
+++ b/Jools/Features/Chat/ChatViewModel.swift
@@ -503,17 +503,20 @@ final class ChatViewModel: PollingServiceDelegate {
             didMutate = true
         }
 
-        if let output = dto.outputs?.first?.pullRequest {
-            if output.url != session.prURL {
-                session.prURL = output.url
+        // Search ALL outputs for a pullRequest — the API can return
+        // multiple outputs (e.g. changeSet + pullRequest) and the PR
+        // is not guaranteed to be first.
+        if let pr = dto.outputs?.lazy.compactMap({ $0.pullRequest }).first {
+            if pr.url != session.prURL {
+                session.prURL = pr.url
                 didMutate = true
             }
-            if output.title != session.prTitle {
-                session.prTitle = output.title
+            if pr.title != session.prTitle {
+                session.prTitle = pr.title
                 didMutate = true
             }
-            if output.description != session.prDescription {
-                session.prDescription = output.description
+            if pr.description != session.prDescription {
+                session.prDescription = pr.description
                 didMutate = true
             }
         }

--- a/Jools/Features/Chat/Snapshots/ActivitySnapshot.swift
+++ b/Jools/Features/Chat/Snapshots/ActivitySnapshot.swift
@@ -82,6 +82,8 @@ struct ProgressSnapshot: Equatable, Sendable {
     let descriptionText: String?
     let bashCommands: [BashCommandSnapshot]
     let messageSegments: [MarkdownSegment]
+    /// File paths changed in this progress step (from changeSet artifacts).
+    let changedFiles: [String]
 }
 
 struct BashCommandSnapshot: Equatable, Sendable, Identifiable {
@@ -105,6 +107,12 @@ struct CompletionSnapshot: Equatable, Sendable {
     /// Empty when the session produced no unified-diff patch.
     let diffFiles: [DiffFile]
     let duration: TimeInterval
+    /// Pull request URL from the session outputs. `nil` when the
+    /// session didn't produce a PR (repoless sessions, or sessions
+    /// that failed before creating a PR).
+    let prURL: String?
+    let prTitle: String?
+    let prDescription: String?
 }
 
 // MARK: - MarkdownSegment

--- a/Jools/Features/Chat/Snapshots/ActivitySnapshotBuilder.swift
+++ b/Jools/Features/Chat/Snapshots/ActivitySnapshotBuilder.swift
@@ -99,10 +99,14 @@ extension ActivitySnapshot.Kind {
                 .compactMap { $0.changeSet?.gitPatch?.changedFiles }
                 .flatMap { $0 } ?? []
 
+            // Normalize blank/whitespace-only strings to nil so the
+            // emptiness check below and the view layer don't need to
+            // handle "" vs nil separately.
+            let title = entity.progressTitle?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+            let desc = entity.progressDescription?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+
             // Filter out completely empty progress events that would
             // render as invisible zero-height rows in the list.
-            let title = entity.progressTitle
-            let desc = entity.progressDescription
             if bash.isEmpty && segments.isEmpty && changedFiles.isEmpty
                 && title == nil && desc == nil {
                 return nil
@@ -150,4 +154,8 @@ extension ActivitySnapshot.Kind {
             self = .unsupported(rawType: "UNKNOWN")
         }
     }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
 }

--- a/Jools/Features/Chat/Snapshots/ActivitySnapshotBuilder.swift
+++ b/Jools/Features/Chat/Snapshots/ActivitySnapshotBuilder.swift
@@ -20,10 +20,15 @@ enum ActivitySnapshotBuilder {
     /// as the primary source and falls back to the SwiftData
     /// relationship array if the `@Query` hasn't yet observed
     /// freshly inserted rows (brief race during initial load).
+    ///
+    /// The optional `session` parameter supplies PR data for
+    /// `CompletionSnapshot`. It lives on `SessionEntity`, not
+    /// `ActivityEntity`, so we thread it through here.
     @MainActor
     static func build(
         from query: [ActivityEntity],
-        fallback: [ActivityEntity]
+        fallback: [ActivityEntity],
+        session: SessionEntity? = nil
     ) -> [ActivitySnapshot] {
         let source: [ActivityEntity]
         if !query.isEmpty {
@@ -31,7 +36,7 @@ enum ActivitySnapshotBuilder {
         } else {
             source = fallback.sorted { $0.createdAt < $1.createdAt }
         }
-        return source.compactMap { ActivitySnapshot(entity: $0) }
+        return source.compactMap { ActivitySnapshot(entity: $0, session: session) }
     }
 }
 
@@ -40,8 +45,8 @@ enum ActivitySnapshotBuilder {
 extension ActivitySnapshot {
 
     @MainActor
-    init?(entity: ActivityEntity) {
-        guard let kind = Kind(entity: entity) else { return nil }
+    init?(entity: ActivityEntity, session: SessionEntity? = nil) {
+        guard let kind = Kind(entity: entity, session: session) else { return nil }
         self.id = entity.id
         self.type = entity.type
         self.createdAt = entity.createdAt
@@ -54,7 +59,7 @@ extension ActivitySnapshot {
 extension ActivitySnapshot.Kind {
 
     @MainActor
-    init?(entity: ActivityEntity) {
+    init?(entity: ActivityEntity, session: SessionEntity? = nil) {
         switch entity.type {
         case .userMessaged:
             self = .userMessage(text: entity.messageContent ?? "")
@@ -89,11 +94,26 @@ extension ActivitySnapshot.Kind {
                     success: !dto.isLikelyFailure
                 )
             }
+            // Extract changed file names from changeSet artifacts
+            let changedFiles = entity.decodedContent?.artifacts?
+                .compactMap { $0.changeSet?.gitPatch?.changedFiles }
+                .flatMap { $0 } ?? []
+
+            // Filter out completely empty progress events that would
+            // render as invisible zero-height rows in the list.
+            let title = entity.progressTitle
+            let desc = entity.progressDescription
+            if bash.isEmpty && segments.isEmpty && changedFiles.isEmpty
+                && title == nil && desc == nil {
+                return nil
+            }
+
             self = .progressUpdated(snapshot: ProgressSnapshot(
-                title: entity.progressTitle,
-                descriptionText: entity.progressDescription,
+                title: title,
+                descriptionText: desc,
                 bashCommands: bash,
-                messageSegments: segments
+                messageSegments: segments,
+                changedFiles: changedFiles
             ))
 
         case .planApproved:
@@ -117,7 +137,10 @@ extension ActivitySnapshot.Kind {
                 diffDeletions: entity.diffDeletions,
                 changedFiles: entity.changedFiles,
                 diffFiles: parsedDiffFiles,
-                duration: 0
+                duration: session.map { entity.createdAt.timeIntervalSince($0.createdAt) } ?? 0,
+                prURL: session?.prURL,
+                prTitle: session?.prTitle,
+                prDescription: session?.prDescription
             ))
 
         case .sessionFailed:

--- a/Jools/Features/Chat/Snapshots/ActivitySnapshotRow.swift
+++ b/Jools/Features/Chat/Snapshots/ActivitySnapshotRow.swift
@@ -348,18 +348,52 @@ private struct SnapshotPlanStepRow: View {
     let step: PlanStepSnapshot
     let number: Int
 
-    var body: some View {
-        HStack(alignment: .center, spacing: JoolsSpacing.sm) {
-            StepNumberBadgeFromSnapshot(number: number, status: step.status)
-            Text(step.title)
-                .font(.joolsBody)
-                .foregroundStyle(.primary)
-                .lineLimit(2)
-                .multilineTextAlignment(.leading)
-            Spacer()
+    @State private var isExpanded = false
+
+    private var hasDescription: Bool {
+        if let desc = step.description, !desc.isEmpty, desc != step.title {
+            return true
         }
-        .padding(.horizontal, JoolsSpacing.md)
-        .padding(.vertical, JoolsSpacing.sm)
+        return false
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                guard hasDescription else { return }
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(alignment: .center, spacing: JoolsSpacing.sm) {
+                    StepNumberBadgeFromSnapshot(number: number, status: step.status)
+                    Text(step.title)
+                        .font(.joolsBody)
+                        .foregroundStyle(.primary)
+                        .lineLimit(isExpanded ? nil : 2)
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+                    if hasDescription {
+                        Image(systemName: "chevron.down")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, JoolsSpacing.md)
+            .padding(.vertical, JoolsSpacing.sm)
+
+            if isExpanded, let desc = step.description, !desc.isEmpty {
+                RenderedMarkdown(text: desc, font: .joolsCaption)
+                    .opacity(0.65)
+                    .padding(.horizontal, JoolsSpacing.md)
+                    .padding(.leading, 28 + JoolsSpacing.sm) // align with title text
+                    .padding(.bottom, JoolsSpacing.sm)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
         .accessibilityIdentifier("plan.step.\(number)")
     }
 }
@@ -412,8 +446,17 @@ private struct StepNumberBadgeFromSnapshot: View {
 private struct ProgressRow: View {
     let progress: ProgressSnapshot
 
+    /// Whether the description body is expanded (for progress cards
+    /// that have a long description, like "Running code review...").
+    @State private var isExpanded = false
+
+    /// True when the title has a description that adds information
+    /// beyond what messageSegments already show (e.g. a URL).
+    private var hasTitle: Bool { progress.title != nil }
+
     var body: some View {
         VStack(alignment: .leading, spacing: JoolsSpacing.sm) {
+            // 1. Bash commands
             ForEach(progress.bashCommands) { bash in
                 CommandCardView(
                     command: bash.command,
@@ -423,7 +466,34 @@ private struct ProgressRow: View {
                 )
             }
 
-            if !progress.messageSegments.isEmpty {
+            // 2. File update card from changeSet artifacts
+            if !progress.changedFiles.isEmpty {
+                FileUpdateView(files: progress.changedFiles) { _ in }
+            }
+
+            // 3. Title + description card — takes priority when a
+            //    title exists, because messageSegments would just
+            //    redundantly render the same title text. The card
+            //    also surfaces the description (e.g. a URL) that
+            //    messageSegments would miss entirely.
+            if let title = progress.title {
+                ProgressTitleCard(
+                    title: title,
+                    description: progress.descriptionText,
+                    isExpanded: $isExpanded
+                )
+            } else if let desc = progress.descriptionText,
+                      progress.bashCommands.isEmpty && progress.messageSegments.isEmpty {
+                ProgressTitleCard(
+                    title: desc,
+                    description: nil,
+                    isExpanded: $isExpanded
+                )
+            }
+
+            // 4. Message segments — only when there's no title
+            //    (otherwise the title card above already covers it)
+            if !hasTitle && !progress.messageSegments.isEmpty {
                 HStack(alignment: .top, spacing: JoolsSpacing.md) {
                     JulesAvatarView(size: 28)
 
@@ -446,6 +516,64 @@ private struct ProgressRow: View {
     }
 }
 
+/// Compact progress card that shows a title and an optional
+/// expandable description. Matches the Jules web UI's collapsible
+/// progress cards (e.g. "Running code review ...").
+private struct ProgressTitleCard: View {
+    let title: String
+    let description: String?
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: JoolsSpacing.md) {
+            JulesAvatarView(size: 28)
+
+            VStack(alignment: .leading, spacing: JoolsSpacing.xs) {
+                if let description, !description.isEmpty {
+                    // Title + expandable description
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isExpanded.toggle()
+                        }
+                    } label: {
+                        HStack {
+                            Text(title)
+                                .font(.joolsBody.weight(.medium))
+                                .foregroundStyle(.primary)
+                                .multilineTextAlignment(.leading)
+                            Spacer(minLength: 4)
+                            Image(systemName: "chevron.down")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                                .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                        }
+                    }
+                    .buttonStyle(.plain)
+
+                    if isExpanded {
+                        RenderedMarkdown(text: description, font: .joolsCaption)
+                            .opacity(0.65)
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                } else {
+                    // Title only
+                    Text(title)
+                        .font(.joolsBody)
+                        .foregroundStyle(.primary)
+                }
+            }
+            .padding(.horizontal, JoolsSpacing.md)
+            .padding(.vertical, JoolsSpacing.sm)
+            .background(Color.joolsBubbleAgent)
+            .clipShape(RoundedRectangle(cornerRadius: JoolsRadius.lg))
+
+            Spacer(minLength: 40)
+        }
+        .padding(.horizontal, JoolsSpacing.md)
+        .accessibilityIdentifier("chat.progress-title")
+    }
+}
+
 // MARK: - Plan approved
 
 private struct PlanApprovedRow: View {
@@ -462,52 +590,74 @@ private struct PlanApprovedRow: View {
 }
 
 // MARK: - Completion row
+//
+// Layout adapted from the Jules web UI "Ready for review" card:
+// ┌──────────────────────────────────────┐
+// │  ✓ Session completed          +N -N  │
+// │  ┌─────────────────────────────────┐ │
+// │  │ commit message ...              │ │
+// │  └─────────────────────────────────┘ │
+// │  [file pills scrollable ...]         │
+// │  ┌─────────────────────────────────┐ │
+// │  │ ⑂ Pull Request           Open   │ │
+// │  │ PR title                        │ │
+// │  │ View PR ↗    Copy URL           │ │
+// │  └─────────────────────────────────┘ │
+// └──────────────────────────────────────┘
 
 private struct CompletionRow: View {
     let completion: CompletionSnapshot
 
+    @Environment(\.openURL) private var openURL
     @State private var showingDiffViewer = false
+    @State private var showCopiedToast = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: JoolsSpacing.sm) {
-            HStack(spacing: JoolsSpacing.xs) {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(Color.joolsSuccess)
-                Text("Session completed")
-                    .font(.joolsBody.weight(.semibold))
-                Spacer()
-            }
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: status + diff stats
+            HStack {
+                HStack(spacing: JoolsSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color.joolsSuccess)
+                    Text("Session completed")
+                        .font(.joolsBody.weight(.semibold))
+                }
 
+                Spacer()
+
+                if completion.diffAdditions > 0 || completion.diffDeletions > 0 {
+                    HStack(spacing: JoolsSpacing.sm) {
+                        Text("+\(completion.diffAdditions)")
+                            .foregroundStyle(Color.joolsSuccess)
+                            .fontWeight(.semibold)
+                        Text("-\(completion.diffDeletions)")
+                            .foregroundStyle(Color.joolsError)
+                            .fontWeight(.semibold)
+                    }
+                    .font(.joolsCaption)
+                }
+            }
+            .padding(JoolsSpacing.md)
+
+            // Commit message in a dark inset card
             if let message = completion.commitMessage, !message.isEmpty {
                 Text(message)
-                    .font(.joolsBody)
+                    .font(.joolsCaption)
                     .foregroundStyle(.primary)
-                    .lineLimit(6)
+                    .lineLimit(4)
+                    .padding(JoolsSpacing.sm)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.joolsSurfaceElevated)
+                    .clipShape(RoundedRectangle(cornerRadius: JoolsRadius.sm))
+                    .padding(.horizontal, JoolsSpacing.md)
+                    .padding(.bottom, JoolsSpacing.sm)
             }
 
-            if completion.diffAdditions > 0 || completion.diffDeletions > 0 {
-                HStack(spacing: JoolsSpacing.sm) {
-                    Label("+\(completion.diffAdditions)", systemImage: "plus.circle.fill")
-                        .foregroundStyle(Color.joolsSuccess)
-                    Label("-\(completion.diffDeletions)", systemImage: "minus.circle.fill")
-                        .foregroundStyle(Color.joolsError)
-                }
-                .font(.joolsCaption)
-            }
-
+            // Changed files as scrollable pills
             if !completion.changedFiles.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: JoolsSpacing.xs) {
                         ForEach(completion.changedFiles, id: \.self) { file in
-                            // Tapping any file pill opens the full
-                            // DiffViewerView as a sheet so users
-                            // can read the actual hunk-level changes,
-                            // not just the file name. This wiring was
-                            // lost when the chat surface migrated to
-                            // the snapshot architecture; restoring
-                            // it here uses `completion.diffFiles`
-                            // which is pre-parsed by
-                            // ActivitySnapshotBuilder.
                             FilePill(filename: file, status: .modified) {
                                 if !completion.diffFiles.isEmpty {
                                     showingDiffViewer = true
@@ -515,11 +665,104 @@ private struct CompletionRow: View {
                             }
                         }
                     }
+                    .padding(.horizontal, JoolsSpacing.md)
                 }
+                .padding(.bottom, JoolsSpacing.sm)
+            }
+
+            // Duration
+            if completion.duration > 0 {
+                HStack {
+                    Spacer()
+                    HStack(spacing: JoolsSpacing.xxs) {
+                        Image(systemName: "clock")
+                        Text("~\(Self.formatDuration(completion.duration))")
+                    }
+                    .font(.joolsCaption)
+                    .foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, JoolsSpacing.md)
+                .padding(.bottom, JoolsSpacing.xs)
+            }
+
+            // PR card (only when session produced a pull request)
+            if let prURL = completion.prURL {
+                Divider()
+                    .padding(.horizontal, JoolsSpacing.md)
+
+                VStack(alignment: .leading, spacing: JoolsSpacing.xs) {
+                    HStack(spacing: JoolsSpacing.xs) {
+                        Image(systemName: "arrow.triangle.pull")
+                            .foregroundStyle(Color.joolsAccent)
+                        Text("Pull Request")
+                            .font(.joolsCaption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        PRStatusBadge(status: .open)
+                    }
+
+                    if let title = completion.prTitle {
+                        Text(title)
+                            .font(.joolsBody)
+                            .lineLimit(2)
+                    }
+
+                    HStack {
+                        // Use Button + openURL instead of Link.
+                        // Link inside a List row expands its tap
+                        // target to fill the entire row — a known
+                        // SwiftUI behavior. Button respects its
+                        // own bounds.
+                        Button {
+                            if let url = URL(string: prURL) {
+                                openURL(url)
+                            }
+                        } label: {
+                            HStack(spacing: JoolsSpacing.xxs) {
+                                Image(systemName: "arrow.up.right.square")
+                                Text("View PR")
+                            }
+                            .font(.joolsCaption.weight(.medium))
+                            .foregroundStyle(Color.joolsAccent)
+                            .padding(.horizontal, JoolsSpacing.sm)
+                            .padding(.vertical, JoolsSpacing.xxs)
+                            .background(Color.joolsAccent.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: JoolsRadius.sm))
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+
+                        Spacer()
+
+                        Button {
+                            UIPasteboard.general.string = prURL
+                            HapticManager.shared.lightImpact()
+                            withAnimation { showCopiedToast = true }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                withAnimation { showCopiedToast = false }
+                            }
+                        } label: {
+                            HStack(spacing: JoolsSpacing.xxs) {
+                                Image(systemName: showCopiedToast ? "checkmark" : "doc.on.doc")
+                                Text(showCopiedToast ? "Copied!" : "Copy URL")
+                            }
+                            .font(.joolsCaption)
+                            .foregroundStyle(showCopiedToast ? Color.joolsSuccess : .secondary)
+                            .padding(.horizontal, JoolsSpacing.sm)
+                            .padding(.vertical, JoolsSpacing.xxs)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(JoolsSpacing.md)
             }
         }
-        .padding(JoolsSpacing.md)
         .background(Color.joolsSuccess.opacity(0.08))
+        .overlay(
+            RoundedRectangle(cornerRadius: JoolsRadius.md)
+                .stroke(Color.joolsSuccess.opacity(0.3), lineWidth: 1)
+        )
         .clipShape(RoundedRectangle(cornerRadius: JoolsRadius.md))
         .padding(.horizontal, JoolsSpacing.md)
         .sheet(isPresented: $showingDiffViewer) {
@@ -533,6 +776,39 @@ private struct CompletionRow: View {
                         Button("Done") { showingDiffViewer = false }
                     }
                 }
+            }
+        }
+    }
+
+    private static func formatDuration(_ interval: TimeInterval) -> String {
+        let totalMinutes = Int(interval / 60)
+        if totalMinutes < 1 { return "<1 min" }
+        if totalMinutes < 60 { return "\(totalMinutes) min" }
+        let hours = totalMinutes / 60
+        let mins = totalMinutes % 60
+        return mins > 0 ? "\(hours)h \(mins)m" : "\(hours)h"
+    }
+}
+
+// MARK: - Rendered markdown helper
+//
+// Reusable view for rendering markdown text in collapsible sections
+// (progress descriptions, plan step details). Uses the same
+// FlatMarkdownRenderer pipeline as agent message bubbles.
+
+private struct RenderedMarkdown: View {
+    let segments: [MarkdownSegment]
+
+    init(text: String, font: Font = .joolsCaption) {
+        // Render once at init; the segments are Equatable so SwiftUI
+        // will skip re-rendering if the text hasn't changed.
+        self.segments = FlatMarkdownRenderer.render(text)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JoolsSpacing.xxs) {
+            ForEach(segments) { segment in
+                MarkdownSegmentView(segment: segment)
             }
         }
     }

--- a/Jools/Features/Chat/Snapshots/ActivitySnapshotRow.swift
+++ b/Jools/Features/Chat/Snapshots/ActivitySnapshotRow.swift
@@ -357,33 +357,42 @@ private struct SnapshotPlanStepRow: View {
         return false
     }
 
+    private var stepContent: some View {
+        HStack(alignment: .center, spacing: JoolsSpacing.sm) {
+            StepNumberBadgeFromSnapshot(number: number, status: step.status)
+            Text(step.title)
+                .font(.joolsBody)
+                .foregroundStyle(.primary)
+                .lineLimit(isExpanded ? nil : 2)
+                .multilineTextAlignment(.leading)
+            Spacer()
+            if hasDescription {
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+            }
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Button {
-                guard hasDescription else { return }
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isExpanded.toggle()
-                }
-            } label: {
-                HStack(alignment: .center, spacing: JoolsSpacing.sm) {
-                    StepNumberBadgeFromSnapshot(number: number, status: step.status)
-                    Text(step.title)
-                        .font(.joolsBody)
-                        .foregroundStyle(.primary)
-                        .lineLimit(isExpanded ? nil : 2)
-                        .multilineTextAlignment(.leading)
-                    Spacer()
-                    if hasDescription {
-                        Image(systemName: "chevron.down")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .rotationEffect(.degrees(isExpanded ? 180 : 0))
+            if hasDescription {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded.toggle()
                     }
+                } label: {
+                    stepContent
                 }
+                .buttonStyle(.plain)
+                .padding(.horizontal, JoolsSpacing.md)
+                .padding(.vertical, JoolsSpacing.sm)
+            } else {
+                stepContent
+                    .padding(.horizontal, JoolsSpacing.md)
+                    .padding(.vertical, JoolsSpacing.sm)
             }
-            .buttonStyle(.plain)
-            .padding(.horizontal, JoolsSpacing.md)
-            .padding(.vertical, JoolsSpacing.sm)
 
             if isExpanded, let desc = step.description, !desc.isEmpty {
                 RenderedMarkdown(text: desc, font: .joolsCaption)
@@ -798,11 +807,11 @@ private struct CompletionRow: View {
 
 private struct RenderedMarkdown: View {
     let segments: [MarkdownSegment]
+    let font: Font
 
     init(text: String, font: Font = .joolsCaption) {
-        // Render once at init; the segments are Equatable so SwiftUI
-        // will skip re-rendering if the text hasn't changed.
         self.segments = FlatMarkdownRenderer.render(text)
+        self.font = font
     }
 
     var body: some View {
@@ -811,6 +820,7 @@ private struct RenderedMarkdown: View {
                 MarkdownSegmentView(segment: segment)
             }
         }
+        .font(font)
     }
 }
 

--- a/Jools/Features/Chat/Snapshots/FlatMarkdownRenderer.swift
+++ b/Jools/Features/Chat/Snapshots/FlatMarkdownRenderer.swift
@@ -144,16 +144,51 @@ enum FlatMarkdownRenderer {
                         var run = InlineAttributedStringBuilder.build(from: paragraph)
                         run.mergeAttributes(paragraphStyleAttributes(indent: 16))
                         currentText.append(run)
+                    } else if let nestedUL = block as? UnorderedList {
+                        // Nested unordered list — render each sub-item
+                        // with deeper indent and inline formatting.
+                        appendNewline()
+                        appendNestedList(nestedUL, indent: 32)
+                    } else if let nestedOL = block as? OrderedList {
+                        appendNewline()
+                        appendNestedList(nestedOL, indent: 32)
                     } else {
-                        // Nested list or blockquote inside a list
-                        // item — fall back to a flat text run.
-                        var run = AttributedString(block.format().trimmingCharacters(in: .whitespacesAndNewlines))
-                        run.font = .joolsBody
+                        // Other nested blocks — render with inline
+                        // formatting so bold/code/links are preserved.
+                        var run = InlineAttributedStringBuilder.build(from: block as Markup)
                         run.mergeAttributes(paragraphStyleAttributes(indent: 32))
                         currentText.append(run)
                     }
                     if blockIndex < itemBlocks.count - 1 {
                         appendNewline()
+                    }
+                }
+                appendNewline()
+            }
+        }
+
+        /// Render a nested list (inside a parent list item) with
+        /// proper indentation and inline formatting (bold, code, etc).
+        private mutating func appendNestedList(_ list: any ListItemContainer, indent: CGFloat) {
+            let items = Array(list.listItems)
+            let ordered = list is OrderedList
+            for (index, item) in items.enumerated() {
+                let prefix: String = ordered ? "\(index + 1). " : "– "
+                var prefixRun = AttributedString(prefix)
+                prefixRun.font = .joolsBody
+                prefixRun.foregroundColor = .secondary
+                prefixRun.mergeAttributes(paragraphStyleAttributes(indent: indent))
+                currentText.append(prefixRun)
+
+                for block in item.blockChildren {
+                    if let paragraph = block as? Paragraph {
+                        var run = InlineAttributedStringBuilder.build(from: paragraph)
+                        run.mergeAttributes(paragraphStyleAttributes(indent: indent))
+                        currentText.append(run)
+                    } else {
+                        var run = InlineAttributedStringBuilder.build(from: block as Markup)
+                        run.mergeAttributes(paragraphStyleAttributes(indent: indent + 16))
+                        currentText.append(run)
                     }
                 }
                 appendNewline()

--- a/Jools/Features/Chat/Views/FilePillView.swift
+++ b/Jools/Features/Chat/Views/FilePillView.swift
@@ -101,7 +101,10 @@ struct FilePill: View {
 
 // MARK: - File Update View
 
-/// Shows "Updated" label with file pill badges
+/// Shows "Updated" label with a horizontally scrollable row of file
+/// pills. The previous `HStack` layout squeezed pills to 3-4 chars
+/// on phone screens because the "Updated" label, 3 pills, and the
+/// overflow text competed for space in a non-scrollable row.
 struct FileUpdateView: View {
     let files: [String]
     let maxVisible: Int
@@ -114,24 +117,32 @@ struct FileUpdateView: View {
     }
 
     var body: some View {
-        HStack(spacing: JoolsSpacing.xs) {
-            // "Updated" label
-            Text("Updated")
-                .font(.joolsCaption)
-                .foregroundStyle(.secondary)
-
-            // Visible file pills
-            ForEach(files.prefix(maxVisible), id: \.self) { file in
-                FilePill(filename: file) {
-                    onFileTap(file)
+        VStack(alignment: .leading, spacing: JoolsSpacing.xxs) {
+            HStack(spacing: JoolsSpacing.xs) {
+                Text("Updated")
+                    .font(.joolsCaption)
+                    .foregroundStyle(.secondary)
+                if files.count > maxVisible {
+                    Text("\(files.count) files")
+                        .font(.joolsCaption)
+                        .foregroundStyle(.tertiary)
                 }
             }
 
-            // Overflow indicator
-            if files.count > maxVisible {
-                Text("and \(files.count - maxVisible) more")
-                    .font(.joolsCaption)
-                    .foregroundStyle(.tertiary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: JoolsSpacing.xs) {
+                    ForEach(files.prefix(maxVisible), id: \.self) { file in
+                        FilePill(filename: file) {
+                            onFileTap(file)
+                        }
+                    }
+                    if files.count > maxVisible {
+                        Text("+\(files.count - maxVisible)")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                            .padding(.horizontal, JoolsSpacing.xs)
+                    }
+                }
             }
         }
         .padding(.horizontal, JoolsSpacing.md)

--- a/Jools/Features/Dashboard/DashboardViewModel.swift
+++ b/Jools/Features/Dashboard/DashboardViewModel.swift
@@ -108,10 +108,10 @@ final class DashboardViewModel: ObservableObject {
                 existing.stateRaw = dto.state ?? SessionState.unspecified.rawValue
                 existing.updatedAt = dto.updateTime ?? Date()
 
-                if let output = dto.outputs?.first?.pullRequest {
-                    existing.prURL = output.url
-                    existing.prTitle = output.title
-                    existing.prDescription = output.description
+                if let pr = dto.outputs?.lazy.compactMap({ $0.pullRequest }).first {
+                    existing.prURL = pr.url
+                    existing.prTitle = pr.title
+                    existing.prDescription = pr.description
                 }
             } else {
                 // Insert new session

--- a/Jools/Features/Dashboard/SessionsListView.swift
+++ b/Jools/Features/Dashboard/SessionsListView.swift
@@ -198,10 +198,10 @@ struct SessionsListView: View {
                 existing.stateRaw = dto.state ?? SessionState.unspecified.rawValue
                 existing.updatedAt = dto.updateTime ?? Date()
 
-                if let output = dto.outputs?.first?.pullRequest {
-                    existing.prURL = output.url
-                    existing.prTitle = output.title
-                    existing.prDescription = output.description
+                if let pr = dto.outputs?.lazy.compactMap({ $0.pullRequest }).first {
+                    existing.prURL = pr.url
+                    existing.prTitle = pr.title
+                    existing.prDescription = pr.description
                 }
             } else {
                 let entity = SessionEntity(from: dto)

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -430,3 +430,57 @@ iOS notification sounds must be ≤30s in `.caf`, `.aiff`, or `.wav`.
 Python's `wave` module only writes `.wav`. Convert with:
 `afconvert input.wav output.caf -d LEI16 -f caff`. Apply -12dB gain
 to synthesized sine waves — raw amplitude 1.0 is painfully loud.
+
+---
+
+## Jules REST API vs web UI
+
+### API `outputs` array: never assume `.first`
+
+The `SessionDTO.outputs` array can contain multiple items (e.g. a
+`changeSet` output AND a `pullRequest` output). The PR is not
+guaranteed to be first. Use
+`dto.outputs?.lazy.compactMap({ $0.pullRequest }).first` to search
+all outputs. This bit us in 4 places (ChatViewModel, DashboardViewModel,
+SessionsListView, Entities.swift).
+
+### Web UI uses batch RPC, not the REST API
+
+The Jules web UI calls `/_/Swebot/data/batchexecute` (Google's
+internal batch RPC) which returns richer data than the public REST
+API. The "Ready for review" card's runtime ("Time: 47 mins") is a
+server-computed field not exposed in the REST API. We approximate
+with `sessionCompleted.createTime - session.createTime` and prefix
+with `~`.
+
+### `changeSet` artifacts on progress events have no patch content
+
+Progress-event `changeSet` artifacts only carry `baseCommitId` — no
+`unidiffPatch` or `patch`. The "Updated config.go, tests.go and 8
+more" display in the web UI derives file names from the batch RPC,
+not from the activity's changeSet. Our `changedFiles` extraction
+from progress events is correct code but will often be empty.
+
+---
+
+## SwiftUI List row gotchas
+
+### `Link` inside a `List` row expands its tap target to the full row
+
+SwiftUI `Link` registers as a navigation destination at the `List`
+infrastructure level. No amount of `.fixedSize()` or
+`.contentShape()` constrains it. Replace with `Button` +
+`@Environment(\.openURL)` when the link needs a bounded tap target
+(e.g. a "View PR" button alongside a "Copy URL" button).
+
+---
+
+## FlatMarkdownRenderer
+
+### Nested lists fall back to raw text
+
+When a list item contains a sub-list (e.g. `- **bold:** text` inside
+a numbered list), the renderer's fallback path used
+`block.format()` which returns literal markdown (`**bold**`). Fixed
+by adding `appendNestedList()` and routing non-paragraph blocks
+through `InlineAttributedStringBuilder` instead of `format()`.


### PR DESCRIPTION
## Summary

Addresses three user-reported issues with the session chat surface, verified against the Jules web UI (`jules.google.com`) for the same sessions.

- **Invisible progress events**: `PROGRESS_UPDATED` activities with title/description but no bash output rendered as zero-height rows, leaving blank gaps in the timeline. Now renders compact expandable cards with markdown-formatted descriptions.
- **Missing PR link**: `dto.outputs?.first?.pullRequest` only checked the first output — the PR was in the second. Fixed in all 4 sync paths. Completion card now shows PR section with View PR + Copy URL buttons.
- **Late notifications**: BGAppRefreshTask had a 15-minute interval with no foreground catch-up. Reduced to 5 minutes and added immediate session check on foreground return.

## Changes

### Progress events (`c2d971d`)
- `ProgressSnapshot` gains `changedFiles` field from changeSet artifacts
- New `ProgressTitleCard` with chevron-expandable descriptions
- Title takes priority over redundant messageSegments (prevents losing description URLs)
- Empty progress events filtered out instead of rendering invisible rows
- `FileUpdateView` layout fixed: vertical with horizontal scroll (was truncating pills to 3-4 chars)
- `FlatMarkdownRenderer`: nested lists now go through `InlineAttributedStringBuilder` instead of raw `block.format()` (fixes literal `**bold**` markers showing)

### PR data extraction (`f270955`)
- All 4 sync paths (`ChatViewModel`, `DashboardViewModel`, `SessionsListView`, `Entities.swift`) changed from `.first?.pullRequest` to `.lazy.compactMap({ $0.pullRequest }).first`

### Completion card redesign (`f00af6b`)
- Layout matches Jules web UI "Ready for review" card: header + diff stats, commit message in dark inset, scrollable file pills, `~duration`, PR section
- `Link` replaced with `Button` + `@Environment(\.openURL)` — `Link` inside a `List` row expands its tap target to the full row
- Plan steps gain expandable descriptions with markdown rendering
- All expanded sections at 65% opacity for visual hierarchy

### Notification delivery (`8ef3724`)
- `BGAppRefreshTask` interval: 15 min → 5 min
- `MainTabView` gains `scenePhase` observer: immediate session check on `.active`, schedule next BGTask on `.background`

### Documentation (`caf53f9`)
- `CLAUDE.md`: new "Verification protocol" section — Jules web UI is the reference, use AXe + Chrome DevTools MCP
- `docs/LEARNINGS.md`: entries for outputs array ordering, batch RPC vs REST API, Link-in-List tap targets, nested list rendering

## Test plan

- [x] `make build` succeeds
- [x] `make test` — all test suites pass
- [x] `make lint` — no new warnings
- [x] Verified on iPhone 17 Pro simulator (iOS 26.4) against the `indrasvat/dootsabha` session
- [x] Progress title cards render (previously invisible)
- [x] PR card shows with View PR + Copy URL (previously missing)
- [x] View PR opens correct URL (`github.com/indrasvat/dootsabha/pull/11`)
- [x] Copy URL copies to clipboard (not opening URL)
- [x] Tapping empty space between buttons does nothing (no Link bleed)
- [x] Expandable descriptions render markdown correctly (bold, lists, code)
- [x] Duration shows `~40 min` (approximate, prefixed with ~)
- [x] Plan steps expand with chevron to show descriptions
- [x] Foreground re-check detects session transitions on app return

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PR details (URL, title, description) to session completion view with "View PR" and "Copy URL" options.
  * Progress updates now display changed files with file change cards.
  * Duration display added to completed sessions.
  * Plan steps and progress step descriptions are now collapsible/expandable.

* **Improvements**
  * App now refreshes sessions and checks notifications immediately when brought to foreground.
  * Background refresh interval optimized to 5 minutes for faster updates.
  * File updates display is now scrollable for better accessibility.
  * Enhanced markdown rendering for complex nested lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->