### PR TITLE
fix: open Jules settings in system Safari for cookie sharing

### DIFF
--- a/Jools/Features/Onboarding/OnboardingView.swift
+++ b/Jools/Features/Onboarding/OnboardingView.swift
@@ -87,7 +87,16 @@ struct OnboardingView: View {
                     // to a marketing page where the sign-in button
                     // is below the fold and easy to miss.
                     Button(action: {
-                        if let url = URL(string: "https://jules.google.com/settings/api") {
+                        // Go through Google AccountChooser with a
+                        // continue URL to the Jules API settings page.
+                        // This bypasses the Jules landing page entirely
+                        // (which has a viewport bug hiding the sign-in
+                        // button on mobile Safari). If the user is
+                        // already signed in, Google skips the chooser
+                        // and redirects straight to /settings/api.
+                        let settingsURL = "https://jules.google.com/settings/api"
+                        let encodedContinue = settingsURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? settingsURL
+                        if let url = URL(string: "https://accounts.google.com/AccountChooser?continue=\(encodedContinue)") {
                             UIApplication.shared.open(url)
                             waitingForSafariReturn = true
                         }

--- a/Jools/Features/Onboarding/OnboardingView.swift
+++ b/Jools/Features/Onboarding/OnboardingView.swift
@@ -6,8 +6,9 @@ struct OnboardingView: View {
     @EnvironmentObject private var dependencies: AppDependency
     @Environment(\.colorScheme) private var colorScheme
     @StateObject private var viewModel = OnboardingViewModel()
-    @State private var showingSafari = false
+    @Environment(\.scenePhase) private var scenePhase
     @State private var showingManualEntry = false
+    @State private var waitingForSafariReturn = false
 
     private var titleGradient: LinearGradient {
         if colorScheme == .dark {
@@ -79,8 +80,18 @@ struct OnboardingView: View {
 
                 // Action buttons
                 VStack(spacing: JoolsSpacing.md) {
-                    // Primary: Open Safari to get API key
-                    Button(action: { showingSafari = true }) {
+                    // Primary: Open system Safari (shares Google
+                    // session) so the user lands on /settings/api
+                    // already signed in. SFSafariViewController has
+                    // no cookie sharing, so the Jules SPA redirects
+                    // to a marketing page where the sign-in button
+                    // is below the fold and easy to miss.
+                    Button(action: {
+                        if let url = URL(string: "https://jules.google.com/settings/api") {
+                            UIApplication.shared.open(url)
+                            waitingForSafariReturn = true
+                        }
+                    }) {
                         HStack(spacing: JoolsSpacing.xs) {
                             Image(systemName: "safari")
                             Text("Connect to Jules")
@@ -114,12 +125,13 @@ struct OnboardingView: View {
                     .padding(.bottom, JoolsSpacing.sm)
             }
         }
-        .fullScreenCover(isPresented: $showingSafari) {
-            SafariView(url: URL(string: "https://jules.google.com/settings/api")!)
-                .onDisappear {
-                    viewModel.checkClipboardForAPIKey()
-                }
-                .ignoresSafeArea()
+        .onChange(of: scenePhase) { _, newPhase in
+            // When the user returns from system Safari after copying
+            // their API key, check the clipboard.
+            if newPhase == .active && waitingForSafariReturn {
+                waitingForSafariReturn = false
+                viewModel.checkClipboardForAPIKey()
+            }
         }
         .sheet(isPresented: $showingManualEntry) {
             ManualKeyEntrySheet(viewModel: viewModel)


### PR DESCRIPTION
## Summary

The "Connect to Jules" onboarding button opens `jules.google.com/settings/api` in an in-app `SFSafariViewController`. Since SFSafariViewController doesn't share cookies with the main Safari app, the Jules SPA detects no Google session and redirects to a marketing landing page. The "Sign in to Google" button is below the fold, making it effectively invisible — the user is stuck.

Switches to `UIApplication.shared.open()` which opens in system Safari where the user is typically already signed into Google. This lands them directly on the API settings page. Clipboard check for the API key triggers when the app returns to foreground via `scenePhase`.

## Test plan

- [x] Uninstall app, reinstall, tap "Connect to Jules"
- [x] Verify system Safari opens (not in-app browser)
- [x] Verify landing on `/settings/api` page (not marketing page) when signed into Google
- [x] Copy API key, switch back to app, verify clipboard detection fires