### PR TITLE
fix: include generated pbxproj in release commit instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,8 @@ tree: bumps `MARKETING_VERSION` in `project.yml`, regenerates
 Jools.xcodeproj, rolls `[Unreleased]` in `CHANGELOG.md` into a
 dated `[X.Y.Z]` section. It does NOT auto-commit, auto-tag, or
 auto-push — tagging is destructive and stays under human control.
+The release commit must include all three changed files:
+`git add project.yml CHANGELOG.md Jataayu.xcodeproj/project.pbxproj`.
 
 **All shell logic lives in `scripts/ci-release`**, not in YAML
 `run:` blocks. It has subcommand dispatch: `parse`, `verify`,

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ pre-push: ci ## Pre-push hook target (runs full CI)
 # Example:
 #   make release VERSION=1.0.1
 #   git diff                                  # eyeball the bump
-#   git add project.yml CHANGELOG.md
+#   git add project.yml CHANGELOG.md Jataayu.xcodeproj/project.pbxproj
 #   git commit -m "chore(release): v1.0.1"
 #   git tag -a v1.0.1 -m "v1.0.1"
 #   git push origin main
@@ -443,7 +443,7 @@ endif
 	@echo "  $(CYAN)2.$(RESET) Fill in the [$(VERSION)] CHANGELOG entry with anything"
 	@echo "     not already captured under [Unreleased]."
 	@echo "  $(CYAN)3.$(RESET) Commit and tag:"
-	@echo "       $(WHITE)git add project.yml CHANGELOG.md$(RESET)"
+	@echo "       $(WHITE)git add project.yml CHANGELOG.md Jataayu.xcodeproj/project.pbxproj$(RESET)"
 	@echo "       $(WHITE)git commit -m \"chore(release): v$(VERSION)\"$(RESET)"
 	@echo "       $(WHITE)git tag -a v$(VERSION) -m \"v$(VERSION)\"$(RESET)"
 	@echo "  $(CYAN)4.$(RESET) Push (the tag push triggers .github/workflows/release.yml):"

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Releases are tag-driven — `make release` prepares the working tree and the [`r
 ```bash
 make release VERSION=1.2.3   # bumps project.yml + adds CHANGELOG section
 git diff                     # eyeball it
-git add project.yml CHANGELOG.md
+git add project.yml CHANGELOG.md Jataayu.xcodeproj/project.pbxproj
 git commit -m "chore(release): v1.2.3"
 git tag -a v1.2.3 -m "v1.2.3"
 git push origin HEAD


### PR DESCRIPTION
The release process left project.pbxproj dirty after every tag. Updated all three places (Makefile, README, CLAUDE.md) to include it in the release commit.