### PR TITLE
fix: skip ASC export compliance prompt via Info.plist flag

### DIFF
--- a/Jataayu.xcodeproj/project.pbxproj
+++ b/Jataayu.xcodeproj/project.pbxproj
@@ -707,6 +707,7 @@
 				DEVELOPMENT_TEAM = R65679C4F3;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = fetch;
@@ -812,6 +813,7 @@
 				DEVELOPMENT_TEAM = R65679C4F3;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = fetch;

--- a/docs/app-store-connect-workflow.md
+++ b/docs/app-store-connect-workflow.md
@@ -104,12 +104,15 @@ xcodebuild -exportArchive \
 
 Wait for "Upload succeeded" + "Uploaded package is processing."
 
-### 3. Handle encryption compliance
+### 3. Encryption compliance (automatic)
 
-After processing completes (~2-5 min), App Store Connect may
-prompt for export compliance (encryption). Answer via the web UI
-or `asc` CLI. Jataayu uses HTTPS only (no custom encryption), so
-the answer is typically "No" for proprietary encryption.
+`project.yml` sets `ITSAppUsesNonExemptEncryption: false` in the
+Info.plist, which tells ASC that the app only uses standard HTTPS.
+This skips the "Missing Compliance" prompt automatically on every
+upload. No manual action needed.
+
+If you ever add custom encryption beyond HTTPS/ATS, remove this
+flag and answer the compliance questionnaire manually.
 
 ### 4. Verify
 

--- a/project.yml
+++ b/project.yml
@@ -104,6 +104,10 @@ targets:
         CODE_SIGN_STYLE: Automatic
         GENERATE_INFOPLIST_FILE: true
         INFOPLIST_KEY_UIBackgroundModes: fetch
+        # Jataayu uses only standard HTTPS (URLSession / ATS) — no
+        # custom encryption. This skips the export compliance prompt
+        # on every App Store Connect upload.
+        INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: false
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: true
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: true
         INFOPLIST_KEY_UILaunchScreen_Generation: true


### PR DESCRIPTION
## Summary

Every TestFlight upload required manually answering the encryption compliance prompt. Jataayu uses only standard HTTPS via URLSession/ATS — no custom encryption.

- Added `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: false` to `project.yml`
- Updated `docs/app-store-connect-workflow.md` to reflect the automatic handling

## Test plan

- [x] `make build` succeeds
- [ ] Next ASC upload skips the "Missing Compliance" prompt