### PR TITLE
fix(chat): collapse duplicate Plan approved rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ docs/mocks/explorations/
 
 # Codemap tooling state (per-machine context cache, not for sharing)
 .codemap/
+
+# Claude Code runtime state (lockfiles, scheduled-task bookkeeping)
+.claude/*.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ work that doesn't change behaviour but matters for future maintenance.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Duplicate "Plan approved" row in chat history.** The Jules REST
+  API emits two `planApproved` activities per approval (same
+  `planId`, ~30s apart); the web UI shows only one. Adjacent
+  duplicates are now collapsed at the snapshot layer so Jataayu
+  matches the web UI.
+
 ## [1.2.3] — 2026-04-14
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ work that doesn't change behaviour but matters for future maintenance.
   duplicates are now collapsed at the snapshot layer so Jataayu
   matches the web UI.
 
+### Internal
+
+- **Release discipline.** Release bumps now go through a
+  `chore/release-vX.Y.Z` branch + PR like every other change; the
+  annotated tag is pushed to `main` only after the merge lands.
+  `CLAUDE.md` updated to remove the old "release commit on main"
+  carve-out.
+
 ## [1.2.3] — 2026-04-14
 
 ### Internal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,28 @@ when a task touches them.**
 
 ---
 
+## 🚨 CRITICAL — BRANCH FIRST, ALWAYS
+
+> **NEVER commit or push directly to `main`.**
+> **Before the first edit of any task, create an appropriately-named
+> Conventional-Commits-style branch off `main`.**
+>
+> ```bash
+> git checkout -b fix/<slug>     # bug fixes
+> git checkout -b feat/<slug>    # features
+> git checkout -b chore/<slug>   # tooling / deps / docs
+> git checkout -b refactor/<slug>
+> ```
+>
+> The only things that land on `main` are merged PRs and release
+> tags. If you notice you've already edited files on `main`, stop
+> and move the work to a branch before anything else.
+>
+> This rule has no exceptions. Not "small fix". Not "one-line
+> typo". Not "I'll branch after I see if it works." **Branch first.**
+
+---
+
 ## The essentials (always read)
 
 **Stack:** SwiftUI, Swift 6 strict concurrency, SwiftData, iOS 26+,
@@ -34,10 +56,11 @@ re-paying tuition.
 `docs/LEARNINGS.md`.** That's how the knowledge compounds. Terse
 entries are better than verbose ones.
 
-**Commit-and-push discipline:** never commit unless explicitly
-asked. Never force-push to `main`. Never `rm -rf` DerivedData or
-the keychain without asking. Match the scope of your actions to
-what was actually requested — no drive-by refactors.
+**Commit-and-push discipline:** branch first (see the critical
+block above). Never commit unless explicitly asked. Never
+force-push to `main`. Never `rm -rf` DerivedData or the keychain
+without asking. Match the scope of your actions to what was
+actually requested — no drive-by refactors.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,16 @@ when a task touches them.**
 > git checkout -b refactor/<slug>
 > ```
 >
-> The only things that land on `main` are merged PRs and release
-> tags. If you notice you've already edited files on `main`, stop
-> and move the work to a branch before anything else.
+> The only things that land on `main` are merged PRs and annotated
+> release tags (the tag itself, not the commit it points at — the
+> commit arrived via a merged PR). Even release bumps go through a
+> `chore/release-vX.Y.Z` branch + PR; tag `main` only after the
+> merge lands. If you notice you've already edited files on `main`,
+> stop and move the work to a branch before anything else.
 >
 > This rule has no exceptions. Not "small fix". Not "one-line
-> typo". Not "I'll branch after I see if it works." **Branch first.**
+> typo". Not "release commit, the workflow expects it on main"
+> (it doesn't — it expects the tag). **Branch first.**
 
 ---
 
@@ -209,8 +213,28 @@ tree: bumps `MARKETING_VERSION` in `project.yml`, regenerates
 Jools.xcodeproj, rolls `[Unreleased]` in `CHANGELOG.md` into a
 dated `[X.Y.Z]` section. It does NOT auto-commit, auto-tag, or
 auto-push — tagging is destructive and stays under human control.
-The release commit must include all three changed files:
-`git add project.yml CHANGELOG.md Jataayu.xcodeproj/project.pbxproj`.
+
+**The release commit goes on a branch, not `main`.** Per BRANCH
+FIRST, even release bumps need a PR. Flow:
+
+```bash
+git switch main && git pull
+git checkout -b chore/release-vX.Y.Z
+make release VERSION=X.Y.Z
+git add project.yml CHANGELOG.md Jataayu.xcodeproj/project.pbxproj
+git commit -m "chore(release): vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
+gh pr create --title "chore(release): vX.Y.Z" --body ...
+# review + CI green, then squash-merge
+gh pr merge --squash --delete-branch
+# only now, on main, tag the merge commit:
+git switch main && git pull
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+The `release.yml` workflow triggers on the tag push, not on any
+commit — so the "release commit on main" path never needs to exist.
 
 **All shell logic lives in `scripts/ci-release`**, not in YAML
 `run:` blocks. It has subcommand dispatch: `parse`, `verify`,

--- a/Jools/Features/Chat/Snapshots/ActivitySnapshotBuilder.swift
+++ b/Jools/Features/Chat/Snapshots/ActivitySnapshotBuilder.swift
@@ -36,7 +36,17 @@ enum ActivitySnapshotBuilder {
         } else {
             source = fallback.sorted { $0.createdAt < $1.createdAt }
         }
-        return source.compactMap { ActivitySnapshot(entity: $0, session: session) }
+        let snapshots = source.compactMap { ActivitySnapshot(entity: $0, session: session) }
+        // The Jules API emits two `planApproved` activities (same planId,
+        // ~30s apart) for a single approval — verified against the web UI
+        // which renders exactly one pill per approval. Collapse adjacent
+        // duplicates to match.
+        return snapshots.reduce(into: []) { acc, snap in
+            if snap.kind == .planApproved, acc.last?.kind == .planApproved {
+                return
+            }
+            acc.append(snap)
+        }
     }
 }
 

--- a/JoolsTests/JoolsTests.swift
+++ b/JoolsTests/JoolsTests.swift
@@ -97,6 +97,42 @@ struct JoolsTests {
     // deliberately removed in favor of trusting the API's own
     // `AWAITING_USER_INPUT` state.
 
+    @Test("Snapshot builder collapses adjacent planApproved duplicates")
+    @MainActor
+    func snapshotBuilderCollapsesAdjacentPlanApproved() throws {
+        let base = Date()
+        let activities = [
+            makeActivity(id: "a1", type: .planApproved, createdAt: base, content: ActivityContentDTO()),
+            makeActivity(id: "a2", type: .planApproved, createdAt: base.addingTimeInterval(30), content: ActivityContentDTO())
+        ]
+
+        let snapshots = ActivitySnapshotBuilder.build(from: activities, fallback: [])
+
+        #expect(snapshots.count == 1)
+        #expect(snapshots.first?.kind == .planApproved)
+    }
+
+    @Test("Snapshot builder preserves non-adjacent planApproved entries")
+    @MainActor
+    func snapshotBuilderPreservesNonAdjacentPlanApproved() throws {
+        let base = Date()
+        let activities = [
+            makeActivity(id: "a1", type: .planApproved, createdAt: base, content: ActivityContentDTO()),
+            makeActivity(
+                id: "a2",
+                type: .planGenerated,
+                createdAt: base.addingTimeInterval(10),
+                content: ActivityContentDTO(plan: PlanDTO(id: "p1", steps: []))
+            ),
+            makeActivity(id: "a3", type: .planApproved, createdAt: base.addingTimeInterval(20), content: ActivityContentDTO())
+        ]
+
+        let snapshots = ActivitySnapshotBuilder.build(from: activities, fallback: [])
+
+        #expect(snapshots.count == 3)
+        #expect(snapshots.filter { $0.kind == .planApproved }.count == 2)
+    }
+
     private func makeActivity(
         id: String,
         type: ActivityType,

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -289,6 +289,19 @@ awk -F= '/^JULES_API_KEY=/ {print $2}' .env \
 Then automate the paste via `axe tap --label "Paste from Clipboard"`
 + `axe tap --label "Connect"`.
 
+### Product rename leaves stale bundles on the sim — verify the bundle id
+
+When the product was renamed Jools → Jataayu, the simulator kept
+the old `com.indrasvat.jools` install alongside the new
+`com.indrasvat.jataayu` build. `xcrun simctl launch ... com.indrasvat.jools`
+silently ran the stale binary, so a just-built fix looked broken.
+
+**Fix pattern:** after any rename, `xcrun simctl uninstall $UDID
+<old-bundle-id>` before relaunching, and sanity-check the current
+bundle id with `awk -F= '/PRODUCT_BUNDLE_IDENTIFIER/ {print $2;
+exit}' Jataayu.xcodeproj/project.pbxproj`. If the footer you see
+in-app doesn't match the branch you just built, suspect this.
+
 ---
 
 ## iOS platform quirks
@@ -460,6 +473,17 @@ Progress-event `changeSet` artifacts only carry `baseCommitId` — no
 more" display in the web UI derives file names from the batch RPC,
 not from the activity's changeSet. Our `changedFiles` extraction
 from progress events is correct code but will often be empty.
+
+### API emits duplicate `planApproved` activities per approval
+
+A single plan approval yields two `planApproved` entries in
+`/v1alpha/sessions/{id}/activities`, same `planId`, ~30s apart, no
+events between them (see `docs/api-examples/list-activities-with-plan.json`).
+The web UI renders exactly one pill — dedupe happens client-side.
+We collapse adjacent `.planApproved` snapshots in
+`ActivitySnapshotBuilder.build` (not planId-based, because `planId`
+isn't persisted on `ActivityEntity` and adjacency is sufficient for
+the observed pattern).
 
 ---
 


### PR DESCRIPTION
## Summary

- The Jules REST API emits two `planApproved` activities per approval (same `planId`, ~30s apart); the web UI renders only one pill. Jataayu was rendering both.
- Collapse adjacent `.planApproved` snapshots in `ActivitySnapshotBuilder.build`. Adjacency dedup (not `planId`-based) because `planId` isn't persisted on `ActivityEntity` and adjacency matches the observed API pattern (see `docs/api-examples/list-activities-with-plan.json`).
- Also adds a loud **BRANCH FIRST, ALWAYS** discipline block near the top of `CLAUDE.md`, and LEARNINGS entries for the API duplicate and the Jools→Jataayu bundle-id rename trap.

## Test plan

- [x] `make build`
- [x] Overlay-install on iPhone 17 Pro sim; open the dorikin perf session — single "Plan approved" row
- [x] Visually compared against the same session in the Jules web UI — matches (one pill)
- [ ] CI: SwiftLint + JoolsKit + iOS app pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated duplicate "Plan approved" entries appearing in chat history when approving plans, ensuring clearer and more accurate activity display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->