### PR TITLE
chore(release): v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ work that doesn't change behaviour but matters for future maintenance.
 
 ## [Unreleased]
 
+## [1.2.4] — 2026-04-18
+
 ### Fixed
 
 - **Duplicate "Plan approved" row in chat history.** The Jules REST

--- a/Jataayu.xcodeproj/project.pbxproj
+++ b/Jataayu.xcodeproj/project.pbxproj
@@ -718,7 +718,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.indrasvat.jataayu;
 				PRODUCT_MODULE_NAME = Jools;
 				PRODUCT_NAME = Jataayu;
@@ -824,7 +824,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.indrasvat.jataayu;
 				PRODUCT_MODULE_NAME = Jools;
 				PRODUCT_NAME = Jataayu;

--- a/project.yml
+++ b/project.yml
@@ -91,7 +91,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.indrasvat.jataayu
         PRODUCT_NAME: Jataayu
         PRODUCT_MODULE_NAME: Jools
-        MARKETING_VERSION: "1.2.3"
+        MARKETING_VERSION: "1.2.4"
         CURRENT_PROJECT_VERSION: "1"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         # Pinned to the project owner's individual Apple Developer team


### PR DESCRIPTION
Release bump for v1.2.4. Rolls `[Unreleased]` → `[1.2.4] — 2026-04-18` in CHANGELOG, bumps `MARKETING_VERSION` in `project.yml` and the generated `project.pbxproj`.

## What's in 1.2.4

### Fixed
- Duplicate "Plan approved" row in chat history (#18)

### Internal
- Release discipline: release bumps now go through a `chore/release-vX.Y.Z` branch + PR like every other change; annotated tag pushed to `main` only after the merge lands.

## Test plan

- [x] `make build` locally
- [ ] CI green (SwiftLint + JoolsKit + iOS app)

After merge: tag `main` with `v1.2.4` → `.github/workflows/release.yml` builds + publishes the GitHub Release asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history display by fixing the handling of adjacent duplicate "Plan approved" activity rows, now properly collapsed to align with the web UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->