### PR TITLE
chore(release): v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ work that doesn't change behaviour but matters for future maintenance.
 
 ## [Unreleased]
 
+## [1.2.5] — 2026-04-19
+
 ### Fixed
 
 - **Completed-session re-entry now updates the banner.** When a

--- a/Jataayu.xcodeproj/project.pbxproj
+++ b/Jataayu.xcodeproj/project.pbxproj
@@ -750,7 +750,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.indrasvat.jataayu;
 				PRODUCT_MODULE_NAME = Jools;
 				PRODUCT_NAME = Jataayu;
@@ -856,7 +856,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.indrasvat.jataayu;
 				PRODUCT_MODULE_NAME = Jools;
 				PRODUCT_NAME = Jataayu;

--- a/project.yml
+++ b/project.yml
@@ -91,7 +91,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.indrasvat.jataayu
         PRODUCT_NAME: Jataayu
         PRODUCT_MODULE_NAME: Jools
-        MARKETING_VERSION: "1.2.4"
+        MARKETING_VERSION: "1.2.5"
         CURRENT_PROJECT_VERSION: "1"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         # Pinned to the project owner's individual Apple Developer team


### PR DESCRIPTION
Release bump for v1.2.5. Rolls `[Unreleased]` → `[1.2.5] — 2026-04-19` in CHANGELOG, bumps `MARKETING_VERSION` in `project.yml` + regenerated `project.pbxproj`.

## What's in 1.2.5

### Fixed
- Completed-session re-entry banner (#20)
- Banner "Pull to refresh" now tappable (#20)
- Staleness / infinite retry loop on large sessions — `fields=` mask (874 MB → 16 KB), cursor-always, 120 s URLSession timeout, lazy `unidiffPatch` backfill (#20)

### Internal
- Scenario test harness for Sessions — 4 multi-step integration tests (#21)

## Test plan

- [x] `make build`
- [x] `make test-app` — 14 tests pass (10 unit + 4 scenario)
- [ ] CI green

After merge: tag `v1.2.5` on main → `release.yml` auto-builds the GitHub Release → TestFlight upload via `asc`.